### PR TITLE
support MailHog via net/smtp fallback and keep TLS for real SMTP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,8 +57,8 @@ ASPNETCORE_ENVIRONMENT=Development
 Image__API_GATEWAY_URL=http://recipy-ag:3030
 
 # SMTP
-MAIL_SMTP_HOST=smtp.gmail.com
-MAIL_SMTP_PORT=587
+#MAIL_SMTP_HOST=smtp.gmail.com
+#MAIL_SMTP_PORT=587
 # Docs: Método opción 2 disponible en https://support.google.com/a/answer/176600?hl=en 
 MAIL_SMTP_USER=direccion_de_correo_emisor
 MAIL_SMTP_PASS=application_password_asociado_a_la_cuenta_USER
@@ -78,3 +78,9 @@ RABBITMQ_PORT=5672
 
 # Para recipy-rp
 # API_GATEWAY_URL=http://recipy-ag:3030 # Ya está definido arriba, lo pongo aquí para notar que se usa en recipy-rp
+
+# Para pruebas de mail-ms desde userauth-ms
+MAIL_SMTP_HOST=mailhog
+MAIL_SMTP_PORT=1025
+MAIL_SMTP_USER=no-reply@recipy.local
+MAIL_SMTP_PASS=

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -160,6 +160,17 @@ services:
     networks:
       - frontend
 
+
+  # Servicio de desarrollo para captura y testing de correos
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"  # SMTP
+      - "8025:8025"  # UI web
+    networks:
+      - backend
+
+
   # Servicio de correo asíncrono
   mail-ms:
     build:
@@ -189,6 +200,7 @@ services:
       backend:
         aliases:
           - rabbitmq   # para tests de userauth-ms
+
 
 volumes:
   rabbitmq_data:

--- a/mail-ms/amqp_consumer.go
+++ b/mail-ms/amqp_consumer.go
@@ -7,28 +7,48 @@ import (
     "github.com/streadway/amqp"
 )
 
+// EmailMessage representa el payload esperado en la cola "send-email".
 type EmailMessage struct {
     To      string `json:"to"`
     Subject string `json:"subject"`
     Body    string `json:"body"`
 }
 
+// startAMQPConsumer arranca el consumidor AMQP tras establecer la conexión.
 func startAMQPConsumer(cfg Config) {
     conn, err := amqp.Dial(cfg.AMQPURL)
     if err != nil {
         log.Fatalf("No se pudo conectar a RabbitMQ: %s", err)
     }
+    defer conn.Close()
+
     ch, err := conn.Channel()
     if err != nil {
         log.Fatalf("No se pudo abrir canal AMQP: %s", err)
     }
+    defer ch.Close()
 
-    q, err := ch.QueueDeclare("send-email", true, false, false, false, nil)
+    q, err := ch.QueueDeclare(
+        "send-email", // nombre de la cola
+        true,         // durable
+        false,        // auto-delete
+        false,        // exclusive
+        false,        // no-wait
+        nil,          // args
+    )
     if err != nil {
         log.Fatalf("No se pudo declarar la cola: %s", err)
     }
 
-    msgs, err := ch.Consume(q.Name, "", true, false, false, false, nil)
+    msgs, err := ch.Consume(
+        q.Name, // queue
+        "",     // consumer
+        true,   // auto-ack
+        false,  // exclusive
+        false,  // no-local
+        false,  // no-wait
+        nil,    // args
+    )
     if err != nil {
         log.Fatalf("No se pudo registrar el consumidor: %s", err)
     }
@@ -40,9 +60,11 @@ func startAMQPConsumer(cfg Config) {
             continue
         }
 
-        log.Printf("Enviando correo a %s...", email.To)
+        log.Printf("Enviando correo a %s…", email.To)
         if err := sendEmail(cfg, email.To, email.Subject, email.Body); err != nil {
             log.Printf("Falló el envío: %v", err)
+        } else {
+            log.Printf("Correo enviado a %s", email.To)
         }
     }
 }

--- a/mail-ms/config.go
+++ b/mail-ms/config.go
@@ -3,7 +3,7 @@ package main
 type Config struct {
     SMTPHost string `envconfig:"MAIL_SMTP_HOST" required:"true"`
     SMTPPort int    `envconfig:"MAIL_SMTP_PORT" required:"true"`
-    SMTPUser string `envconfig:"MAIL_SMTP_USER" required:"true"`
-    SMTPPass string `envconfig:"MAIL_SMTP_PASS" required:"true"`
+    SMTPUser string `envconfig:"MAIL_SMTP_USER"`
+    SMTPPass string `envconfig:"MAIL_SMTP_PASS"`
     AMQPURL  string `envconfig:"AMQP_URL" required:"true"`
 }

--- a/mail-ms/handlers.go
+++ b/mail-ms/handlers.go
@@ -1,24 +1,54 @@
 package main
 
 import (
+    "crypto/tls"
+    "fmt"
     "log"
+    "net/smtp"
+
     gomail "gopkg.in/gomail.v2"
 )
 
 func sendEmail(cfg Config, to, subject, body string) error {
+    from := cfg.SMTPUser
+    if from == "" {
+        from = "no-reply@recipy.local"
+    }
+
+    // MailHog (puerto 1025): conexión en texto plano
+    if cfg.SMTPPort == 1025 {
+        msg := []byte(
+            fmt.Sprintf("From: %s\r\n", from) +
+                fmt.Sprintf("To: %s\r\n", to) +
+                fmt.Sprintf("Subject: %s\r\n", subject) +
+                "MIME-Version: 1.0\r\n" +
+                "Content-Type: text/html; charset=UTF-8\r\n" +
+                "\r\n" +
+                body,
+        )
+        addr := fmt.Sprintf("%s:%d", cfg.SMTPHost, cfg.SMTPPort)
+        if err := smtp.SendMail(addr, nil, from, []string{to}, msg); err != nil {
+            log.Printf("Error enviando correo a %s (smtp): %v", to, err)
+            return err
+        }
+        log.Printf("Correo enviado a %s via net/smtp", to)
+        return nil
+    }
+
+    // Producción: gomail con TLS
     m := gomail.NewMessage()
-    m.SetHeader("From", cfg.SMTPUser)
+    m.SetHeader("From", from)
     m.SetHeader("To", to)
     m.SetHeader("Subject", subject)
     m.SetBody("text/html", body)
 
     d := gomail.NewDialer(cfg.SMTPHost, cfg.SMTPPort, cfg.SMTPUser, cfg.SMTPPass)
+    d.TLSConfig = &tls.Config{ServerName: cfg.SMTPHost}
 
     if err := d.DialAndSend(m); err != nil {
-        log.Printf("Error enviando correo a %s: %v", to, err)
+        log.Printf("Error enviando correo a %s (gomail): %v", to, err)
         return err
     }
-
-    log.Printf("Correo enviado a %s", to)
+    log.Printf("Correo enviado a %s via gomail", to)
     return nil
 }

--- a/userauth-ms/requirements.txt
+++ b/userauth-ms/requirements.txt
@@ -16,7 +16,7 @@ passlib==1.7.4
 pluggy==1.6.0
 PyJWT==2.8.0
 pytest==7.4.0
-python-dotenv==1.1.0
+python-dotenv==1.1.0 # También para mail-ms
 requests==2.31.0
 urllib3==2.4.0
 Werkzeug==2.3.7


### PR DESCRIPTION
Cambios principales realizados para integrar **userauth-ms** con el servicio de correo **mail-ms**:

---

## 1. Configuración de RabbitMQ y variables de entorno

* **.env**

  * Se añadieron las variables `AMQP_URL`, `RABBITMQ_HOST` y `RABBITMQ_PORT` para apuntar al broker de RabbitMQ (`mail-broker:5672`).

* **docker-compose.yaml**

  * Se incluyeron los servicios `mail-broker` (RabbitMQ) y `mail-ms` (nuestra Go-app) en la red `backend`.
  * `userauth-ms` ahora depende de `token-db` y de `userauth-postgrest`, pero el envío de eventos de correo sucede vía RabbitMQ.

---

## 2. Cambios en **userauth-ms**

1. **requirements.txt**

   ```diff
   + pika==1.3.1
   ```

2. **app.py**

   * Se importó y configuró **pika** para conectarse a RabbitMQ (usando `RABBIT_URL` o `RABBITMQ_HOST`/`PORT`).
   * En el endpoint `/register`, tras crear al usuario en PostgREST, se publica un mensaje JSON en la cola `emails`:

     ```python
     conn_params = pika.BlockingConnection(params)
     ch = conn_params.channel()
     ch.queue_declare(queue="emails")
     ch.basic_publish(
         exchange="", routing_key="emails",
         body=json.dumps({"type":"welcome","user_id": user_id})
     )
     conn_params.close()
     ```
   * Se dejaron preparados (aunque aún no implementados) puntos para publicar también en `/reset_password`.

3. **tests/conftest.py**

   * El fixture `disable_rabbitmq` sigue interceptando la conexión a RabbitMQ en los tests, de modo que la suite no falla al no encontrar cola real.
   * No fue necesario cambiar los tests de `test_auth.py`: tras la integración, siguen pasando sin modificaciones.

---

## 3. Cambios en **mail-ms** (servicio Go)

1. **config.go**

   * Se utiliza `envconfig` para leer `MAIL_SMTP_*` y `AMQP_URL`.

2. **handlers.go**

   * **Nuevo comportamiento**: si `SMTP_PORT == 1025` (MailHog), usar la librería estándar `net/smtp` en texto plano para no exigir TLS:

     ```go
     if cfg.SMTPPort == 1025 {
         // smtp.SendMail(...)
     }
     ```
   * En entornos reales (p.ej. Gmail), sigue usando `gomail` con TLS.

3. **main.go** y **rest\_producer.go**

   * El consumidor AMQP (`startAMQPConsumer`) ahora escucha la cola `send-email` y llama a `sendEmail(...)` para despachar correos.
   * El servidor REST expone `/send`, `/send-code` y `/send-bulk`, que publican mensajes en la misma cola.

4. **Dockerfile**

   * No hubo cambios sustanciales salvo rebuild normal de la app Go.

---

## 4. Flujo completo verificado

1. **Registro de usuario**

   * Cliente → `userauth-ms` → PostgREST → RabbitMQ → `mail-ms`

2. **mail-ms**

   * Consume el evento `emails` y dispara `sendEmail(...)`.
   * En desarrollo con MailHog (puerto 1025) envía el mensaje y se ve en [http://localhost:8025](http://localhost:8025).

3. **Tests**

   * La suite de `userauth-ms` (`pytest`) sigue pasando sin cambios.
   * No fue necesario mockear el envío real de correo (los tests siguen usando el dummy de RabbitMQ).

---
Obtenemos:

* **userauth-ms** que encola eventos de bienvenida.
* **mail-ms** que los consume y despacha correos contra MailHog o SMTP real.
* Tests y flujos manuales de registro que siguen funcionando.

---

Después de levantar contenedores, obtenemos en la terminal:

```
fnovoas@fnovoas-ubuntu:~/recipy$ sudo docker compose logs -f mail-ms
mail-ms-1  | 2025/06/17 01:54:58 Esperando RabbitMQ… (dial tcp 172.18.0.5:5672: connect: connection refused)
mail-ms-1  | 2025/06/17 01:55:03 RabbitMQ está listo
mail-ms-1  | 2025/06/17 01:55:03 mail-ms escuchando en puerto interno 8080 (REST + AMQP)
^C  
fnovoas@fnovoas-ubuntu:~/recipy$ curl -X POST http://localhost:3030/user/register   -H "Content-Type: application/json"   -d '{"name":"Alice","email":"alice@example.com","username":"alice","password":"AlicePass1!"}'
{
  "message": "User registered"
}
fnovoas@fnovoas-ubuntu:~/recipy$ sudo docker compose logs -f mail-ms
mail-ms-1  | 2025/06/17 01:54:58 Esperando RabbitMQ… (dial tcp 172.18.0.5:5672: connect: connection refused)
mail-ms-1  | 2025/06/17 01:55:03 RabbitMQ está listo
mail-ms-1  | 2025/06/17 01:55:03 mail-ms escuchando en puerto interno 8080 (REST + AMQP)
mail-ms-1  | 2025/06/17 01:55:17 Enviando correo a alice@example.com…
mail-ms-1  | 2025/06/17 01:55:17 Correo enviado a alice@example.com via net/smtp
mail-ms-1  | 2025/06/17 01:55:17 Correo enviado a alice@example.com
^C

```