### PR TITLE
Integrar cache de tokens en Redis y notificaciones via mail-ms

### DIFF
--- a/userauth-db/initdb/02-auth-users-for-postgREST.sql
+++ b/userauth-db/initdb/02-auth-users-for-postgREST.sql
@@ -42,22 +42,20 @@ CREATE OR REPLACE FUNCTION recipy.register_user(
     _name     TEXT,
     _password TEXT,
     _username TEXT
-) RETURNS VOID
+) RETURNS TABLE(id INT)
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 BEGIN
+    RETURN QUERY
     INSERT INTO recipy.users(
-        name,
-        email,
-        username,
-        password_hash
-    ) VALUES (
-        _name,
-        _email,
-        _username,
+        name, email, username, password_hash
+    )
+    VALUES (
+        _name, _email, _username,
         crypt(_password, gen_salt('bf'))
-    );
+    )
+    RETURNING users.id;
 END;
 $$;
 

--- a/userauth-ms/app.py
+++ b/userauth-ms/app.py
@@ -1,54 +1,61 @@
-# userauth-ms/app.py
-
 import os
 import json
 import requests
 from flask import Flask, request, jsonify, abort
 from flask_cors import CORS
-from datetime import timedelta
+from datetime import timedelta, datetime
 from auth import hash_password, verify_password
 from dotenv import load_dotenv
+import psycopg2
+from psycopg2.extras import RealDictCursor
+import pika
+from flask_jwt_extended import (
+    create_access_token,
+    jwt_required,
+    get_jwt_identity,
+    verify_jwt_in_request,
+    JWTManager,
+)
+from redis import Redis
 
-# 1) cargamos el .env ya antes de leer RABBITMQ_*
+# 1) Cargamos variables de entorno de .env antes de cualquier configuración
 load_dotenv()
 
-from flask_jwt_extended import (
-     create_access_token,
-     jwt_required,
-     get_jwt_identity,
-     JWTManager,
- )
+# 2) Configuración de Redis (usa REDIS_URL o los valores REDIS_HOST / REDIS_PORT)
+redis_client = Redis.from_url(
+    os.getenv(
+        "REDIS_URL",
+        f"redis://{os.getenv('REDIS_HOST', 'recipy-cache')}:{os.getenv('REDIS_PORT', 6379)}/0"
+    ),
+    decode_responses=True
+)
 
-# Para token-db
-import psycopg2 
-from psycopg2.extras import RealDictCursor
-from datetime import datetime
-import pika
+# 3) Configuración de RabbitMQ (mail-broker)
 RABBIT_URL  = os.getenv("RABBITMQ_URL",  "amqp://guest:guest@mail-broker/")
 RABBIT_HOST = os.getenv("RABBITMQ_HOST", "mail-broker")
 RABBIT_PORT = int(os.getenv("RABBITMQ_PORT", 5672))
-params = pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
+pika_params = pika.ConnectionParameters(host=RABBIT_HOST, port=RABBIT_PORT)
 
-
+# 4) Inicialización de Flask
 app = Flask(__name__)
 CORS(app)
 
-# URL de PostgREST (userauth-postgrest)
+# 5) Configuración de PostgREST para gestión de usuarios
 PGRST = os.getenv("PGRST_URL", "").rstrip("/")  # ej: http://userauth-postgrest:3000
 HEADERS = {"Content-Type": "application/json"}
 
-# JWT settings
-# JWT_SECRET = os.getenv("JWT_SECRET", "change-me")
-# JWT_ALGORITHM = "HS256"
-# JWT_EXP_HOURS = int(os.getenv("JWT_EXP_HOURS", "24"))
-
-
+# 6) Configuración de JWT
 app.config['JWT_SECRET_KEY'] = os.getenv("JWT_SECRET", "change-me")
-app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(hours=int(os.getenv("JWT_EXP_HOURS", "24")))
+app.config['JWT_ACCESS_TOKEN_EXPIRES'] = timedelta(
+    hours=int(os.getenv("JWT_EXP_HOURS", "24"))
+)
 jwt = JWTManager(app)
 
 
 def get_token_db_conn():
+    """
+    Conexión a la base de datos de tokens (token-db).
+    """
     return psycopg2.connect(
         host="token-db",
         port=5432,
@@ -76,12 +83,12 @@ def pg(path, **kw):
 def register():
     data = request.json or {}
 
-    # 1. Validación básica de campos obligatorios
+    # 1. Validación de campos obligatorios
     for field in ("name", "email", "username", "password"):
         if not data.get(field):
             return jsonify({"error": f"Falta campo {field}"}), 400
 
-    # 2. Preparamos el payload para el RPC de PostgREST
+    # 2. Preparar payload para RPC register_user
     payload = {
         "_name":     data["name"],
         "_email":    data["email"],
@@ -89,57 +96,44 @@ def register():
         "_password": data["password"],
     }
 
-    # 3. Llamada al RPC register_user
-    r = pg("rpc/register_user",
-           method="POST",
-           headers=HEADERS,
-           json=payload)
+    # 3. Llamada al RPC en PostgREST
+    r = pg("rpc/register_user", method="POST", headers=HEADERS, json=payload)
 
-    # 4. Si todo va bien (200 OK o 204 No Content), devolvemos 201 Created
-    if r.status_code in (200, 204):
-        # determinar user_id
-        if r.status_code == 200 and r.headers.get("Content-Type", "").startswith("application/json"):
-            # PostgREST ha devuelto JSON con { id: ... }
-            user_id = r.json().get("id")
-        else:
-            # fue 204 No Content: recuperamos el usuario por username
-            lookup = pg(f"users?username=eq.{data['username']}", headers={"Accept": "application/json"})
-            if lookup.status_code != 200 or not lookup.json():
-                # algo muy raro: falló lookup, devolvemos 500
-                abort(500, "User created but lookup failed")
-            user_id = lookup.json()[0]["id"]
+    # 4. Registro exitoso
+    if r.status_code == 200:
+        resp = r.json()
+        if not resp:
+            abort(500, "RPC no devolvió el ID del usuario")
+        user_id = resp[0]["id"]
 
-        # Disparamos correo de bienvenida vía RabbitMQ a mail-ms
+        # Enviar email de bienvenida vía RabbitMQ
         try:
-            conn_params = pika.BlockingConnection(params)
+            conn_params = pika.BlockingConnection(pika_params)
             ch = conn_params.channel()
-            # mail-ms escucha en la cola "send-email"
             ch.queue_declare(queue="send-email", durable=True)
-            # Formar mensaje según EmailMessage en mail-ms
             email_msg = {
-                "to":    data["email"],
+                "to": data["email"],
                 "subject": "¡Bienvenido a Recipy!",
-                "body":    f"Hola {data['name']},<br><br>Gracias por registrarte en Recipy."
+               "body": f"Hola {data['name']},<br><br>Gracias por registrarte en Recipy."
             }
             ch.basic_publish(
                 exchange="",
                 routing_key="send-email",
                 body=json.dumps(email_msg),
-                properties=pika.BasicProperties(
-                    delivery_mode=2  # mensaje persistente
-                )
+                properties=pika.BasicProperties(delivery_mode=2)
             )
         except Exception as e:
             app.logger.error(f"No se pudo encolar correo de bienvenida: {e}")
         finally:
-            try: conn_params.close()
-            except: pass
+            try:
+                conn_params.close()
+            except:
+                pass
 
         return jsonify({"message": "User registered"}), 201
 
-    # 5. Manejo de claves duplicadas (username o email ya existe)
+    # 5. Manejo de conflictos (username o email duplicado)
     if r.status_code in (409, 422):
-        # PostgREST suele devolver un JSON con detalles o texto plano
         if r.headers.get("Content-Type", "").startswith("application/json"):
             detail = r.json().get("message", r.text)
         else:
@@ -149,7 +143,7 @@ def register():
             "detail": detail
         }), 409
 
-    # 6. Para cualquier otro error, reenviamos el código y el mensaje original
+    # 6. Otros errores
     return abort(r.status_code, r.text)
 
 
@@ -159,9 +153,8 @@ def login():
     if not data.get("username") or not data.get("password"):
         return jsonify({"error": "Missing credentials"}), 400
 
-    # Traemos al usuario por username
-    r = pg(f"users?username=eq.{data['username']}",
-           headers={"Accept": "application/json"})
+    # 1. Verificar usuario en PostgREST
+    r = pg(f"users?username=eq.{data['username']}", headers={"Accept": "application/json"})
     if r.status_code != 200 or not r.json():
         return jsonify({"error": "Invalid username or password"}), 401
 
@@ -169,17 +162,25 @@ def login():
     if not verify_password(data["password"], user["password_hash"]):
         return jsonify({"error": "Invalid username or password"}), 401
 
+    # 2. Crear JWT y guardarlo en token-db
     token = create_access_token(identity=user["id"])
-    # Guardar en token-db:
     exp = datetime.utcnow() + app.config['JWT_ACCESS_TOKEN_EXPIRES']
     conn = get_token_db_conn()
     cur = conn.cursor()
     cur.execute(
-        "INSERT INTO recipy.jwt_tokens (token, user_id, expires_at) VALUES (%s,%s,%s);",
+        "INSERT INTO recipy.jwt_tokens (token, user_id, expires_at) VALUES (%s, %s, %s);",
         (token, user["id"], exp)
     )
     conn.commit()
     conn.close()
+
+    # 3. Cachear token en Redis con TTL igual a la expiración del JWT
+    try:
+        ttl = int(app.config['JWT_ACCESS_TOKEN_EXPIRES'].total_seconds())
+        redis_client.setex(f"token:{token}", ttl, user["id"])
+    except Exception as e:
+        app.logger.error(f"Error cacheando token en Redis: {e}")
+
     return jsonify({"token": token})
 
 
@@ -196,41 +197,32 @@ def profile():
         user.pop("password_hash", None)
         return jsonify(user)
 
-    else:  # PUT
-        update = request.json or {}
-        # Campos permitidos para editar
-        allowed = {"profile_picture", "biography", "location", "birth_date"}
-        payload = {k: v for k, v in update.items() if k in allowed}
-        if not payload:
-            return jsonify({"error": "No valid fields to update"}), 400
+    # PUT: actualización de perfil
+    update = request.json or {}
+    allowed = {"profile_picture", "biography", "location", "birth_date"}
+    payload = {k: v for k, v in update.items() if k in allowed}
+    if not payload:
+        return jsonify({"error": "No valid fields to update"}), 400
 
-        headers = {
-            **HEADERS,
-            "Prefer": "return=representation"
-        }
-        # Incluir el token en la cabecera para PostgREST
-        token = request.headers.get("Authorization").split()[1]
-        headers["Authorization"] = f"Bearer {token}"
+    headers = {
+        **HEADERS,
+        "Prefer": "return=representation",
+        "Authorization": f"Bearer {request.headers.get('Authorization').split()[1]}"
+    }
+    r = pg(f"users?id=eq.{uid}", method="PATCH", headers=headers, json=payload)
+    if r.status_code not in (200, 204):
+        abort(r.status_code, description=r.text)
 
-        r = pg(f"users?id=eq.{uid}",
-               method="PATCH",
-               headers=headers,
-               json=payload)
-
-        if r.status_code not in (200, 204):
-            return abort(r.status_code, description=r.text)
-
-        # PostgREST en PUT con Prefer: return=representation devuelve lista
-        updated = r.json()[0] if r.json() else {}
-        updated.pop("password_hash", None)
-        return jsonify(updated)
+    updated = r.json()[0] if r.json() else {}
+    updated.pop("password_hash", None)
+    return jsonify(updated)
 
 
 @app.route("/me", methods=["GET"])
 @jwt_required()
 def me():
     """
-    Endpoint para obtener el id de usuario ('sub') del JWT enviado.
+    Devuelve el ID del usuario extraído del JWT ('sub').
     """
     return jsonify({"id": str(get_jwt_identity())})
 
@@ -243,38 +235,70 @@ def my_expired_token_callback(jwt_header, jwt_payload):
     }), 401
 
 
-@app.route("/auth/logout", methods=["POST"])
+@app.route("/logout", methods=["POST"])
 @jwt_required()
 def logout():
     token = request.headers.get("Authorization").split()[1]
+
+    # 1. Eliminar de token-db
     conn = get_token_db_conn()
     cur = conn.cursor()
     cur.execute("DELETE FROM recipy.jwt_tokens WHERE token = %s;", (token,))
     conn.commit()
     conn.close()
-    # También publicar revocación en Redis si usas recipy-cache
+
+    # 2. Eliminar de Redis
+    try:
+        redis_client.delete(f"token:{token}")
+    except Exception as e:
+        app.logger.error(f"Error eliminando token de Redis: {e}")
+
     return jsonify({"msg": "Logged out"}), 200
 
 
-@app.route("/auth/validate", methods=["GET"])
+@app.route("/validate", methods=["GET"])
 def validate():
-    token = request.headers.get("Authorization", "").split("Bearer ")[-1]
-    # 1) firma y expiración ya la gestiona Flask-JWT-Extended
+    """
+    Valida que el JWT enviado en Authorization:
+      1) tenga firma y expiración válidas (Flask-JWT-Extended),
+      2) siga activo (no revocado) en Redis o, en su defecto, en token-db.
+    """
+    # 1) Verificar firma y expiración con flask-jwt-extended
     try:
-        identity = jwt._decode_jwt_from_request(request_type="access")
+        verify_jwt_in_request()
+        # get_jwt_identity devuelve el 'sub' del token (user_id)
+        identity = get_jwt_identity()
     except Exception as e:
+        # Firma inválida o token expirado
         return jsonify({"valid": False, "error": str(e)}), 401
 
-    # 2) comprobar existencia en token-db
+    # Extraer el token crudo desde la cabecera Authorization
+    token = request.headers.get("Authorization", "").split("Bearer ")[-1]
+
+    # 2.a) Intentar validar en caché Redis
+    try:
+        # redis_client es instancia de Redis()
+        if redis_client.exists(f"token:{token}"):
+            return jsonify({"valid": True, "user_id": identity}), 200
+    except Exception as e:
+        app.logger.warning(f"Redis error en validate: {e}")
+
+    # 2.b) Fallback: validar en token-db (PostgreSQL)
     conn = get_token_db_conn()
     cur = conn.cursor()
-    cur.execute("SELECT 1 FROM recipy.jwt_tokens WHERE token = %s;", (token,))
+    cur.execute(
+        "SELECT 1 FROM recipy.jwt_tokens WHERE token = %s;",
+        (token,)
+    )
     exists = cur.fetchone() is not None
     conn.close()
+
     if not exists:
+        # Token ha sido revocado o no existe
         return jsonify({"valid": False, "error": "revoked or missing"}), 401
 
-    return jsonify({"valid": True, "user_id": identity["sub"]}), 200
+    # Token válido y activo
+    return jsonify({"valid": True, "user_id": identity}), 200
 
 
 if __name__ == "__main__":

--- a/userauth-ms/requirements.txt
+++ b/userauth-ms/requirements.txt
@@ -22,3 +22,4 @@ urllib3==2.4.0
 Werkzeug==2.3.7
 pika==1.3.1 # Para token-db
 psycopg2-binary==2.9.7 # Para token-db
+redis==5.0.0 # Para recipy-cache


### PR DESCRIPTION
1. **Integración de mail-ms**

   * En el endpoint `/register` de **userauth-ms** publicamos un mensaje de bienvenida en la cola `send-email` de RabbitMQ.
   * **mail-ms** (Go) consume de `send-email` y envía el correo via SMTP o MailHog.

2. **Integración de recipy-cache**

   * Al hacer **login** en **userauth-ms** guardamos el token en Redis (`recipy-cache`) con TTL igual a la expiración.
   * En **logout** eliminamos tanto el registro en **token-db** como la clave en Redis.

3. **Verificación manual**

   * Registramos a Alice → mensaje “User registered” y correo de bienvenida.
   * Login → obtención de token, validación (`/auth/validate`) devuelve `valid:true`.
   * Logout → revocación en **token-db** y en Redis; validación posterior arroja `401 revoked or missing`.
