### PR TITLE
Patrón 1.2.2 Token Binding (primera versión)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -93,3 +93,7 @@ MAIL_SMTP_HOST=mailhog
 MAIL_SMTP_PORT=1025
 MAIL_SMTP_USER=no-reply@recipy.local
 MAIL_SMTP_PASS=
+
+# Para patrón 1.2.2.
+export TOKEN_DB_HOST=localhost
+export TOKEN_DB_PORT=5434

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -38,6 +38,11 @@ function corregir_permisos_image_ms() {
     sudo chmod -R 777 image-ms/image-uploads
 }
 
+function correr_contenedores_build_detach() {
+    echo "Reconstruyendo e iniciando contenedores en background..."
+    sudo docker compose up --build -d
+}
+
 while true; do
     echo ""
     echo "Selecciona una opción:"
@@ -47,6 +52,7 @@ while true; do
     echo "4. Correr los contenedores"
     echo "5. Corregir permisos del volumen recipe-ms"
     echo "6. Eliminar bases de datos"
+    echo "7. Reconstruir y levantar contenedores en background"
     echo "0. Salir"
     read -p "Opción: " opcion
 
@@ -68,6 +74,9 @@ while true; do
             ;;
         6)
             eliminar_bases_datos
+            ;;
+        7)
+            correr_contenedores_build_detach
             ;;
         0)
             echo "Saliendo..."

--- a/token-db/initdb/01-init_tokens.sql
+++ b/token-db/initdb/01-init_tokens.sql
@@ -8,7 +8,8 @@ CREATE TABLE jwt_tokens (
   token      TEXT      NOT NULL,
   user_id INT NOT NULL,
   issued_at  TIMESTAMP NOT NULL DEFAULT NOW(),
-  expires_at TIMESTAMP NOT NULL
+  expires_at TIMESTAMP NOT NULL,
+  issued_ip  TEXT      NOT NULL -- patrón 1.2.2.
 );
 
 CREATE INDEX idx_jwt_tokens_user  ON jwt_tokens(user_id);

--- a/token-db/initdb/02-add-issued-ip.sql
+++ b/token-db/initdb/02-add-issued-ip.sql
@@ -1,0 +1,2 @@
+ALTER TABLE recipy.jwt_tokens
+  ADD COLUMN issued_ip TEXT NOT NULL DEFAULT '';

--- a/token-db/initdb/03-populate-issued-ip.sql
+++ b/token-db/initdb/03-populate-issued-ip.sql
@@ -1,0 +1,12 @@
+-- 3. Depuración de tokens anteriores sin issued_ip
+--    (para entornos existentes: revocamos los JWT creados antes de habilitar Token Binding)
+SET search_path = recipy;
+
+DELETE FROM jwt_tokens
+WHERE issued_ip = '';
+
+'''
+Esto revoca todos los JWT emitidos antes de habilitar Token Binding.
+Tras aplicar la migración, los usuarios deberán volver a autenticarse
+para obtener un token con su binding IP correctamente poblado.
+'''

--- a/userauth-ms/tests/conftest.py
+++ b/userauth-ms/tests/conftest.py
@@ -1,60 +1,126 @@
-# userauth-ms/tests/conftest.py
+# userauth‑ms/tests/conftest.py
 
 import os
 import sys
 import pytest
-import pika
+import importlib.util
 import psycopg2
 from dotenv import load_dotenv
 
-# Asegura que el paquete principal esté en el PYTHONPATH
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# ----------------------------------------------------------------------------
+# Si Flask no está instalado, saltamos todos estos tests
+# ----------------------------------------------------------------------------
+if importlib.util.find_spec("flask") is None:
+    pytest.skip(
+        "Flask no instalado: omitiendo tests de userauth‑ms",
+        allow_module_level=True
+    )
 
-# Carga .env para tener POSTGRES_* y TOKEN_DB_* en os.environ
+# ----------------------------------------------------------------------------
+# Asegura que la aplicación principal esté en el PYTHONPATH
+# ----------------------------------------------------------------------------
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+# ----------------------------------------------------------------------------
+# Carga variables de entorno desde .env
+# ----------------------------------------------------------------------------
 load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
 
-# --- Dummy para RabbitMQ (ya lo tenías) ---
+# ----------------------------------------------------------------------------
+# Fuerza las URLs y credenciales locales de PostgREST y Postgres
+# ----------------------------------------------------------------------------
+os.environ["PGRST_URL"] = os.getenv("PGRST_URL_LOCAL", "http://localhost:3001")
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", os.getenv("POSTGRES_DB", "userauth_db"))
+os.environ.setdefault("POSTGRES_USER", os.getenv("POSTGRES_USER", "postgres"))
+os.environ.setdefault("POSTGRES_PASSWORD", os.getenv("POSTGRES_PASSWORD", ""))
+os.environ.setdefault("TOKEN_DB_HOST", "localhost")
+os.environ.setdefault("TOKEN_DB_PORT", "5434")
+os.environ.setdefault("TOKEN_DB_NAME", os.getenv("TOKEN_DB_NAME", "token_db"))
+os.environ.setdefault("TOKEN_DB_USER", os.getenv("TOKEN_DB_USER", "postgres"))
+os.environ.setdefault("TOKEN_DB_PASSWORD", os.getenv("TOKEN_DB_PASSWORD", ""))
+
+# ----------------------------------------------------------------------------
+# 1) Limpiar tabla de usuarios **una sola vez** al inicio de pytest
+#    Para que el primer POST /register siempre sea 201
+# ----------------------------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def clean_users_table_once():
+    conn = psycopg2.connect(
+        host=os.getenv("POSTGRES_HOST"),
+        port=int(os.getenv("POSTGRES_PORT")),
+        dbname=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+    )
+    try:
+        cur = conn.cursor()
+        cur.execute("TRUNCATE recipy.users RESTART IDENTITY CASCADE;")
+        conn.commit()
+    finally:
+        conn.close()
+
+# ----------------------------------------------------------------------------
+# 2) Dummy RabbitMQ: evita llamadas reales a pika.BlockingConnection
+# ----------------------------------------------------------------------------
 class DummyConnection:
     def __init__(self, params): pass
     def channel(self): return self
-    def queue_declare(self, *args, **kw): pass
-    def basic_publish(self, *args, **kw): pass
+    def queue_declare(self, *args, **kwargs): pass
+    def basic_publish(self, *args, **kwargs): pass
     def close(self): pass
 
 @pytest.fixture(autouse=True)
 def disable_rabbitmq(monkeypatch):
+    try:
+        import pika
+    except ImportError:
+        return  # Si no está pika, no hay que parchear
     monkeypatch.setattr(pika, "BlockingConnection", DummyConnection)
 
-# --- Nuevo fixture para limpiar las tablas antes de cada test ---
+# ----------------------------------------------------------------------------
+# 3) Dummy Redis: parchea redis.Redis.from_url para que no intente conectar
+# ----------------------------------------------------------------------------
 @pytest.fixture(autouse=True)
-def clean_postgres_tables():
-    # Conexión a userauth-db
-    conn1 = psycopg2.connect(
-        host=os.getenv("POSTGRES_HOST", "userauth-db"),
-        port=int(os.getenv("POSTGRES_PORT", 5432)),
-        dbname=os.getenv("POSTGRES_DB", "recipy"),
-        user=os.getenv("POSTGRES_USER"),
-        password=os.getenv("POSTGRES_PASSWORD"),
+def disable_redis(monkeypatch):
+    try:
+        import redis
+    except ImportError:
+        return  # Si no está redis instalado, omitimos
+    class DummyRedis:
+        def __init__(self, *args, **kwargs): pass
+        def get(self, k): return None
+        def setex(self, k, t, v): pass
+        def exists(self, k): return False
+        def delete(self, k): pass
+        def expire(self, k, t): pass
+    # Parcheamos la clase y el método from_url
+    monkeypatch.setattr(redis, "Redis", DummyRedis)
+    monkeypatch.setattr(
+        redis,
+        "from_url",
+        classmethod(lambda cls, *args, **kwargs: DummyRedis())
     )
-    # Conexión a token-db
-    conn2 = psycopg2.connect(
-        host=os.getenv("TOKEN_DB_HOST", "token-db"),
-        port=int(os.getenv("TOKEN_DB_PORT", 5433)),
-        dbname=os.getenv("TOKEN_DB_NAME", "token_db"),
+
+# ----------------------------------------------------------------------------
+# 4) Antes de cada test, vaciamos SOLO la tabla de tokens JWT
+# ----------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def clean_tokens_table():
+    conn = psycopg2.connect(
+        host=os.getenv("TOKEN_DB_HOST"),
+        port=int(os.getenv("TOKEN_DB_PORT")),
+        dbname=os.getenv("TOKEN_DB_NAME"),
         user=os.getenv("TOKEN_DB_USER"),
         password=os.getenv("TOKEN_DB_PASSWORD"),
     )
-
     try:
-        for conn, truncs in (
-            (conn1, [ 'TRUNCATE recipy."users" RESTART IDENTITY CASCADE;' ]),
-            (conn2, [ 'TRUNCATE recipy.jwt_tokens RESTART IDENTITY CASCADE;' ]),
-        ):
-            cur = conn.cursor()
-            for stmt in truncs:
-                cur.execute(stmt)
-            conn.commit()
-            cur.close()
+        cur = conn.cursor()
+        cur.execute("TRUNCATE recipy.jwt_tokens RESTART IDENTITY CASCADE;")
+        conn.commit()
     finally:
-        conn1.close()
-        conn2.close()
+        conn.close()

--- a/userauth-ms/tests/test_auth.py
+++ b/userauth-ms/tests/test_auth.py
@@ -1,47 +1,141 @@
 import os
+import psycopg2
 import pytest
 from app import app as flask_app
 from dotenv import load_dotenv
 
 @pytest.fixture
-def client(tmp_path, monkeypatch):
-    # Carga variables de entorno del .env
+def client():
+    # Carga variables de entorno desde el archivo .env
     load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
     flask_app.config["TESTING"] = True
     return flask_app.test_client()
 
-def test_register_and_login_and_profile(client):
-    # 1. Registro
-    resp = client.post("/register", json={
-        "name": "Test User",
-        "email": "test@example.com",
-        "username": "testuser",
-        "password": "pass123"
-    })
-    assert resp.status_code == 201
-    assert resp.json["message"] == "User registered"
+def get_token_db_conn():
+    """
+    Conexión a la base de datos de tokens para verificar el issued_ip.
+    """
+    return psycopg2.connect(
+        host=os.getenv("TOKEN_DB_HOST", "localhost"),
+        port=int(os.getenv("TOKEN_DB_PORT", "5434")),
+        dbname=os.getenv("TOKEN_DB_NAME", "recipy"),
+        user=os.getenv("TOKEN_DB_USER", "postgres"),
+        password=os.getenv("TOKEN_DB_PASSWORD", "")
+    )
 
-    # 2. Login
-    resp = client.post("/login", json={
-        "username": "testuser",
-        "password": "pass123"
-    })
-    assert resp.status_code == 200
-    token = resp.json.get("token")
+
+def test_register_and_login_and_profile(client):
+    # 1. Registro de usuario
+    resp = client.post(
+        "/register",
+        json={
+            "name": "Test User",
+            "email": "test@example.com",
+            "username": "testuser",
+            "password": "pass123"
+        }
+    )
+    assert resp.status_code == 201
+    assert resp.json.get("message") == "User registered"
+
+    # 2. Login desde una IP específica
+    login_resp = client.post(
+        "/login",
+        json={"username": "testuser", "password": "pass123"},
+        environ_overrides={"REMOTE_ADDR": "192.168.0.77"}
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json.get("token")
     assert token is not None
 
-    # 3. Get Profile
-    resp = client.get("/profile", headers={
-        "Authorization": f"Bearer {token}"
-    })
-    assert resp.status_code == 200
-    data = resp.json
-    assert data["username"] == "testuser"
+    # *** Nueva comprobación: verificar en la base de datos que issued_ip coincide ***
+    conn = get_token_db_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT issued_ip FROM recipy.jwt_tokens WHERE token = %s",
+        (token,)
+    )
+    issued_ip = cur.fetchone()[0]
+    cur.close()
+    conn.close()
+    assert issued_ip == "192.168.0.77"
+
+    # 3. Acceso al perfil con la misma IP (debe ser exitoso)
+    profile_resp = client.get(
+        "/profile",
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "192.168.0.77"}
+    )
+    assert profile_resp.status_code == 200
+    data = profile_resp.json
+    assert data.get("username") == "testuser"
     assert "password_hash" not in data
 
-    # 4. Update Profile
-    resp = client.put("/profile", json={
-        "location": "Bogotá"
-    }, headers={"Authorization": f"Bearer {token}"})
+    # 4. Actualización de perfil (ubicación)
+    update_resp = client.put(
+        "/profile",
+        json={"location": "Bogotá"},
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "192.168.0.77"}
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json.get("location") == "Bogotá"
+
+
+def test_token_binding_rejects_on_ip_change(client):
+    # Login desde localhost
+    resp = client.post(
+        "/login",
+        json={"username": "testuser", "password": "pass123"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"}
+    )
     assert resp.status_code == 200
-    assert resp.json["location"] == "Bogotá"
+    token = resp.json.get("token")
+
+    # Petición válida con la misma IP
+    r_ok = client.get(
+        "/profile",
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"}
+    )
+    assert r_ok.status_code == 200
+
+    # Petición desde otra IP distinta (debe rechazarse)
+    r_bad = client.get(
+        "/profile",
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "10.0.0.5"}
+    )
+    assert r_bad.status_code == 401
+    # Verificar mensaje de error: token inválido o mismatch de IP
+    err_msg = r_bad.json.get("msg") or r_bad.json.get("error", "")
+    assert "Token inválido" in err_msg or "IP mismatch" in err_msg
+
+
+def test_validate_endpoint_token_binding(client):
+    # Login con IP consistente
+    login_resp = client.post(
+        "/login",
+        json={"username": "testuser", "password": "pass123"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"}
+    )
+    assert login_resp.status_code == 200
+    token = login_resp.json.get("token")
+
+    # Validación OK desde la misma IP
+    r1 = client.get(
+        "/validate",
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"}
+    )
+    assert r1.status_code == 200
+    assert r1.json().get("valid") is True
+
+    # Validación FAIL por IP distinta
+    r2 = client.get(
+        "/validate",
+        headers={"Authorization": f"Bearer {token}"},
+        environ_overrides={"REMOTE_ADDR": "10.0.0.5"}
+    )
+    assert r2.status_code == 401
+    assert "IP mismatch" in r2.json().get("error", "")


### PR DESCRIPTION
Para poner en marcha el patrón **1.2.2 – Token Binding**, realizamos estos cambios:

1. **Migraciones de base de datos**

   * **01-init\_tokens.sql**: creamos la tabla `jwt_tokens` con la nueva columna `issued_ip TEXT NOT NULL`.
   * **02-add-issued-ip.sql**: añadimos `issued_ip` a entornos ya existentes, dándole valor por defecto `''`.
   * **03-populate-issued-ip.sql** (nueva): borramos todos los registros con `issued_ip = ''` para forzar a que, al renovar sesión, los tokens se emitan con su IP de origen correctamente registrada.

2. **Captura y almacenamiento del fingerprint**

   * En `userauth‑ms/app.py` aplicamos `ProxyFix(x_for=1, x_proto=1)` para confiar en `X-Forwarded-For`.
   * Implementamos `get_client_ip()`, que extrae la IP real (primera de `X-Forwarded-For` o `request.remote_addr`).
   * Al hacer **login**, tras `create_access_token()`, llamamos a `get_client_ip()` y guardamos esa IP junto al token en `jwt_tokens(…, issued_ip)`.

3. **Validación de binding en cada petición**

   * Definimos un handler `@jwt.token_in_blocklist_loader` que, antes de cada ruta protegida:

     1. Extrae `jti` y token completo.
     2. Consulta primero Redis (`token_ip:<jti>`) y, en cache‑miss, PostgreSQL (`issued_ip`).
     3. Si la IP actual difiere de la almacenada, revoca el token (lo borra de BD y de Redis) y lo marca como “bloqueado”.

4. **Adaptación del endpoint `/validate`**

   * Extendimos la lógica para verificar binding IP dentro de `/validate`, devolviendo siempre un JSON con `.json()` para que los tests unitarios funcionen sin parches manuales.

5. **Pruebas automáticas en `userauth‑ms/tests`**

   * Creamos tests que:

     * Verifican que, tras login desde una IP A, en la base de tokens `issued_ip` coincide con A.
     * Aseguran que acceder a rutas protegidas desde la misma IP funciona, pero desde una distinta devuelve 401.
     * Comproban que `/validate` responde `valid: true` con la IP original y 401 con “IP mismatch” cuando cambia.

Con todo ello garantizamos que **cada JWT sólo sea válido desde la IP con la que fue emitido**, y que cualquier cambio de origen revoca el token de forma inmediata.


### Pruebas pasadas exitosamente en la terminal
Obtuvimos:

```
fnovoas@fnovoas-ubuntu:~/recipy$ source .venv/bin/activate
(.venv) fnovoas@fnovoas-ubuntu:~/recipy$ pytest userauth-ms/tests -q
...                                                                      [100%]
=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/passlib/utils/__init__.py:854
  /home/fnovoas/recipy/.venv/lib/python3.12/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

userauth-ms/tests/test_auth.py::test_register_and_login_and_profile
userauth-ms/tests/test_auth.py::test_token_binding_rejects_on_ip_change
userauth-ms/tests/test_auth.py::test_validate_endpoint_token_binding
  /home/fnovoas/recipy/userauth-ms/app.py:300: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    exp       = datetime.utcnow() + app.config['JWT_ACCESS_TOKEN_EXPIRES']

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
3 passed, 4 warnings in 0.32s
```

También le puse una séptima opción al cleanup.sh: que ejecute `sudo docker compose up --build -d`, porque lo uso frecuentemente.